### PR TITLE
Update mentions of database_prefix to table_prefix

### DIFF
--- a/blog-extractor-cli.php
+++ b/blog-extractor-cli.php
@@ -194,7 +194,7 @@ class Blog_Extract extends WP_CLI_Command {
 				WP_CLI::success( "$export_file created! ($filesize)" );
 
 				$prefix = WP_CLI::colorize( "%P{$wpdb->prefix}%n" );
-				WP_CLI::line( 'In your new install, set the database prefix to '. $prefix );
+				WP_CLI::line( 'In your new install in wp-config.php, set the $table_prefix to '. $prefix );
 				WP_CLI::line( 'You\'ll also need to do a search-replace for the url change' );
 
 				$old_url = untrailingslashit( $details->domain. $details->path );

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ Creates an tar file in the WordPress root directory. Tar file contains:
 
 In setting up the standalone site, a few things need to be done:
 
- * in `wp-config.php` change the database prefix to match the ID'd prefix from the multisite (this is given in the success message)
+ * in `wp-config.php` change the $table_prefix to match the ID'd prefix from the multisite (this is given in the success message)
  * after the tables are imported
   * run the search-replace command to change the URLs
   * move the uploads from the /sites/{id}/ directory to the main /uploads/ folder


### PR DESCRIPTION
In the docs and shell prompts you mention database prefix, but in WP Config its referred to as $table_prefix, I updated some details ~ feel free to do with as you wish :+1: 

Otherwise, :100: great plugin, it does exactly what I wanted it to do. I tested with OSX + MAMP PRO, so feel free to tag me if you get any issues with a similar env.
